### PR TITLE
chore: stop tracking frontend environment file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+/packages/frontend/.env

--- a/packages/frontend/.env
+++ b/packages/frontend/.env
@@ -1,4 +1,0 @@
-VITE_API_URL=http://localhost:8000
-
-# Gemini API Key - Required for AI interpretation features
-VITE_GEMINI_API_KEY=AIzaSyAdHtVjOf1lqvquwp2jwKg8MiaghU8YHq4


### PR DESCRIPTION
## Scope

- stop tracking `packages/frontend/.env`
- ignore that exact path going forward

The credential formerly stored there was already rotated by the operator. This is a narrow source-hygiene change: the file contents were not inspected, and the much larger tracked generated/vendor tree is intentionally outside this PR pending repository-value triage.

## Verification

- staged mutation boundary contained only `.gitignore` and `packages/frontend/.env`
- `git diff --check`